### PR TITLE
add voice to the workshop title and text

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
-  <title>W3C Workshop on Smart Agents</title>
+  <title>W3C Workshop on Smart Voice Agents</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="style.css">
   <meta name="twitter:site" content="@w3c">
@@ -10,12 +10,12 @@
 </head>
 
 <body>
-<h1>W3C Workshop on Smart Agents</h1>
+<h1>W3C Workshop on Smart Voice Agents</h1>
 <h2>@@Day@@ @@Month@@ 2025, virtual event</h2>
 
 <main id="main" class="main">
 <section id="home">
-<p>This is a Call-for-Participation for the W3C Workshop on Smart Agents.</p>
+<p>This is a Call-for-Participation for the W3C Workshop on Smart Voice Agents.</p>
 <p>The workshop is free, although you will need to email a brief proposal. Please see the <!-- a href="speakers.html"-->@@@information for speakers@@@<!-- /a--> for detail.</p>
 
 <section>
@@ -48,17 +48,17 @@
 <h2>Possible topics</h2>
 <p>The following list of possible topics is quite broad as a starting point and will actually be reduced depending on the interests of participants.</p>
 <ul>
-<li>Clarification of use cases of smart agents and their requirements</li>
+<li>Clarification of use cases of smart voice agents and their requirements</li>
 <li>Summary of the current status:<ul>
 <li>Overview of existing browser support and platforms, for example smart speakers and mobile phones</li>
 <li>Integration of LLMs to enhance browser capabilities and platforms</li>
-<li>Common interoperability issues for smart agents among browsers and platforms</li>
+<li>Common interoperability issues for smart voice agents among browsers and platforms</li>
 <li>APIs in the presence of LLMs</li>
 </ul>
 </li>
-<li>Needs of the users and developers of smart agents:<ul>
-<li>User interfaces to smart agents, including accessibility issues raised by smart agent technology</li>
-<li>Enhanced interaction with LLMs in the context of smart agents for improved usability, addressing issues such as:<ul>
+<li>Needs of the users and developers of smart voice agents:<ul>
+<li>User interfaces to smart voice agents, including accessibility issues raised by smart agent technology</li>
+<li>Enhanced interaction with LLMs in the context of smart voice agents for improved usability, addressing issues such as:<ul>
 <li>Hallucinations: LLMs may generate outputs that seem plausible but are factually incorrect.</li>
 <li>Ambiguity in outputs: Inconsistent or vague responses can cause confusion in automated workflows.</li>
 <li>Lack of accountability: Identifying the root cause of errors in an LLM’s predictions can be challenging.</li>
@@ -69,7 +69,7 @@
 <li>Integrating multiple interchangeable modalities (typing, handwriting, voice, etc.).</li>
 </ul>
 </li>
-<li>Underlying technologies of smart agents:<ul>
+<li>Underlying technologies of smart voice agents:<ul>
 <li>Advanced integration and orchestration of multiple agents</li>
 <li>Agents, services, and devices from various vendors</li>
 <li>Standardized data formats and protocols for data and control transfer</li>


### PR DESCRIPTION
e.g., "Smart Voice Agents" for the workshop title, corresponding to [Dirk's edit for README.md](https://github.com/w3c/smartagents-workshop/commit/dfe43ca86d7d79020e5f5a9564fb075d5f003e40) .


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/smartagents-workshop/pull/1.html" title="Last updated on May 23, 2025, 6:38 AM UTC (6f38182)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/smartagents-workshop/1/d76ee81...6f38182.html" title="Last updated on May 23, 2025, 6:38 AM UTC (6f38182)">Diff</a>